### PR TITLE
Drop-in python version, ported from the pascal version

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/errflags.py
+++ b/errflags.py
@@ -28,10 +28,11 @@ import sys
 import time
 
 # Constants
-ErrFlagsVersion = '2.99.9 beta'
+ErrFlagsVersion = '2.99.10 beta'
 codec     = 'latin_1'
 comma     = ','
 crlf      = '\r\n'
+eof       = chr(26)
 daynumstr = " -- Day number "
 unpub     = "-Unpublished-"
 DEFAULT_CTL_FILE_NAMES = ('ErrFlags.ctl', 'errflags.ctl')
@@ -755,7 +756,7 @@ def CheckSegment(inbound_path, segment_filename, report_filename, notify_node):
 
   for line in InFile:
     line = line.rstrip()    # remove CR
-    if line and line[0] == chr(26):  # Ignore 'soft' EOF character
+    if line and line[0] == eof:  # Ignore 'soft' EOF character
       line = line[1:]
       if not line:
         continue
@@ -774,6 +775,7 @@ def CheckSegment(inbound_path, segment_filename, report_filename, notify_node):
 
   InFile.close()
   if Touch:
+    OutFile.write(eof)
     OutFile.close()
     os.remove(infname)
     crc_line = crc_line.rstrip('0123456789') + ("%05d" % crc)
@@ -790,8 +792,7 @@ def CheckSegment(inbound_path, segment_filename, report_filename, notify_node):
     print(crc_line, file=OutFile)
     if not is_crcline(line):
       print(line, file=OutFile)
-    for line in InFile:
-      print(line.rstrip(), file=OutFile)
+    OutFile.write(InFile.read())
     InFile.close()
     OutFile.close()
     try:

--- a/errflags.py
+++ b/errflags.py
@@ -1,0 +1,912 @@
+#!/usr/bin/python3
+#
+# ErrFlags v3.0  Checks nodelist segments for flag errors.
+# Copyright (C) 2022  Wilfred van Velzen
+#
+# This version is based on the earlier pascal version developed by:
+# Jonny Bergdahl later modified by Johan Zwiekhorst, and Niels Joncheere.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import glob
+import os
+import os.path
+import subprocess
+import sys
+import time
+
+# Constants
+ErrFlagsVersion = '2.99.9 beta'
+codec     = 'latin_1'
+comma     = ','
+crlf      = '\r\n'
+daynumstr = " -- Day number "
+unpub     = "-Unpublished-"
+DEFAULT_CTL_FILE_NAMES = ('ErrFlags.ctl', 'errflags.ctl')
+DEFAULT_TAB_FILE_NAMES = ('ErrFlags.tab', 'errflags.tab')
+DEFAULT_CMT_FILE_NAMES = ('ErrFlags.cmt', 'errflags.cmt')
+
+cmtFileName    = ""
+ctlFileName    = ""
+ExecuteCmd     = ""
+ExecutePath    = ""
+InboundPath    = ""
+NoErrCmd       = ""
+NotifyCmd      = ""
+NotifyPath     = ""
+oldDir         = ""
+tabFileName    = ""
+UnCompressArc  = ""
+UnCompressZip  = ""
+ctlFile        = None
+RptFile        = None
+BaudDefault    = 300
+DefaultNet     = 0
+DefaultZone    = 0
+MaxEntryLength = 157
+SegmentNum     = 0
+TotBaudErr     = 0
+TotCaseConv    = 0
+TotConverted   = 0
+TotDelEntry    = 0
+TotDupErr      = 0
+TotFlagErr     = 0
+TotPhoneErr    = 0
+TotPrefixErr   = 0
+TotPvtErr      = 0
+TotReduErr     = 0
+TotSpaces      = 0
+TotTailCommas  = 0
+TotUserErr     = 0
+ThisCaseConv   = 0
+ThisConverted  = 0
+ThisDupErr     = 0
+ThisFlagErr    = 0
+ThisReduErr    = 0
+ThisUserErr    = 0
+ThisPrefixErr  = 0
+ThisSpaces     = 0
+ThisTailCommas = 0
+ThisDelEntry   = 0
+ThisPhoneErr   = 0
+ThisPvtErr     = 0
+ThisBaudErr    = 0
+ThisZone       = 0
+ThisNet        = 0
+Touch          = True
+AnyProcessed   = False
+
+
+class TSegmentFile:
+  def __init__(self, file_name, rpt_file, notifier):
+    self.FileName = file_name
+    self.RptFile  = rpt_file
+    self.Notifier = notifier
+
+
+class TConvFlag:
+  def __init__(self, first, last):
+    self.First = first
+    self.Last  = last
+
+
+SegmentFiles       = []
+DelEntrys          = []
+Baudrates          = []
+ApprFlags          = []
+CatFlags           = []
+UserFlags          = []
+ConvFlags          = []
+ReduntFlags        = []
+ReduntForPrefFlags = []
+
+
+#
+# Generic functions
+#
+
+# Converts the input string into an int.
+def str2int(s):
+  try:
+    return int(s)
+  except:
+    return 0
+
+
+# Returns a temporary full path name for the given path name.
+def GetTempFileName(path):
+  return os.path.join(os.path.dirname(path), 'NLSEGtmp.$$$')
+
+
+# This function returns the first word in a string, and removes it from the original string.
+# Used to read the setup files
+def first_word(line):
+  if not line:
+    return "", ""
+  r = line.split(maxsplit=1)
+  return r if len(r) > 1 else (r[0], "")
+
+
+# This function works as the above, but for comma separated files like the nodelist
+def extract(line):
+  if not line:
+    return "", ""
+  r = line.split(comma, maxsplit=1)
+  return r if len(r) > 1 else (r[0], "")
+
+
+crc_table = [
+  0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7, 0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
+  0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6, 0x9339, 0x8318, 0xB37B, 0xA35A, 0xD3BD, 0xC39C, 0xF3FF, 0xE3DE,
+  0x2462, 0x3443, 0x0420, 0x1401, 0x64E6, 0x74C7, 0x44A4, 0x5485, 0xA56A, 0xB54B, 0x8528, 0x9509, 0xE5EE, 0xF5CF, 0xC5AC, 0xD58D,
+  0x3653, 0x2672, 0x1611, 0x0630, 0x76D7, 0x66F6, 0x5695, 0x46B4, 0xB75B, 0xA77A, 0x9719, 0x8738, 0xF7DF, 0xE7FE, 0xD79D, 0xC7BC,
+  0x48C4, 0x58E5, 0x6886, 0x78A7, 0x0840, 0x1861, 0x2802, 0x3823, 0xC9CC, 0xD9ED, 0xE98E, 0xF9AF, 0x8948, 0x9969, 0xA90A, 0xB92B,
+  0x5AF5, 0x4AD4, 0x7AB7, 0x6A96, 0x1A71, 0x0A50, 0x3A33, 0x2A12, 0xDBFD, 0xCBDC, 0xFBBF, 0xEB9E, 0x9B79, 0x8B58, 0xBB3B, 0xAB1A,
+  0x6CA6, 0x7C87, 0x4CE4, 0x5CC5, 0x2C22, 0x3C03, 0x0C60, 0x1C41, 0xEDAE, 0xFD8F, 0xCDEC, 0xDDCD, 0xAD2A, 0xBD0B, 0x8D68, 0x9D49,
+  0x7E97, 0x6EB6, 0x5ED5, 0x4EF4, 0x3E13, 0x2E32, 0x1E51, 0x0E70, 0xFF9F, 0xEFBE, 0xDFDD, 0xCFFC, 0xBF1B, 0xAF3A, 0x9F59, 0x8F78,
+  0x9188, 0x81A9, 0xB1CA, 0xA1EB, 0xD10C, 0xC12D, 0xF14E, 0xE16F, 0x1080, 0x00A1, 0x30C2, 0x20E3, 0x5004, 0x4025, 0x7046, 0x6067,
+  0x83B9, 0x9398, 0xA3FB, 0xB3DA, 0xC33D, 0xD31C, 0xE37F, 0xF35E, 0x02B1, 0x1290, 0x22F3, 0x32D2, 0x4235, 0x5214, 0x6277, 0x7256,
+  0xB5EA, 0xA5CB, 0x95A8, 0x8589, 0xF56E, 0xE54F, 0xD52C, 0xC50D, 0x34E2, 0x24C3, 0x14A0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+  0xA7DB, 0xB7FA, 0x8799, 0x97B8, 0xE75F, 0xF77E, 0xC71D, 0xD73C, 0x26D3, 0x36F2, 0x0691, 0x16B0, 0x6657, 0x7676, 0x4615, 0x5634,
+  0xD94C, 0xC96D, 0xF90E, 0xE92F, 0x99C8, 0x89E9, 0xB98A, 0xA9AB, 0x5844, 0x4865, 0x7806, 0x6827, 0x18C0, 0x08E1, 0x3882, 0x28A3,
+  0xCB7D, 0xDB5C, 0xEB3F, 0xFB1E, 0x8BF9, 0x9BD8, 0xABBB, 0xBB9A, 0x4A75, 0x5A54, 0x6A37, 0x7A16, 0x0AF1, 0x1AD0, 0x2AB3, 0x3A92,
+  0xFD2E, 0xED0F, 0xDD6C, 0xCD4D, 0xBDAA, 0xAD8B, 0x9DE8, 0x8DC9, 0x7C26, 0x6C07, 0x5C64, 0x4C45, 0x3CA2, 0x2C83, 0x1CE0, 0x0CC1,
+  0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8, 0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
+]
+
+
+def crc16(crc: int, data: bytes):
+  """
+  CRC-16 (CCITT) implemented with a precomputed lookup table
+  """
+  for byte in data:
+    crc = ((crc << 8) ^ crc_table[(crc >> 8) ^ byte]) & 0xFFFF
+  return crc
+
+
+def crc16str(crc: int, data: str):
+  return crc16(crc, data.encode(codec))
+
+
+# Replace case-insensitive first occurrence only
+def ireplace(old, new, text):
+  i = text.lower().find(old.lower())
+  if i == -1:
+    return text
+  return text[:i] + new + text[i + len(old):]
+
+#
+# Program specific functions and procedures
+#
+
+# len(";A * Nodelist for *, * *, 2022 -- Day number 035 : *") = 52
+def is_crcline(line):
+  return len(line) > 50 and line[0:3] == ';A ' and daynumstr in line
+
+
+def print_and_report(msg, prechar='#'):
+  global RptFile
+
+  print(prechar + ' ' + msg)
+  print(' ' + msg, file=RptFile)
+
+
+# Initialises the program and extracts parameters
+def SignOn():
+  global ctlFileName, oldDir
+
+  print("ErrFlags V" + ErrFlagsVersion, " Copyright (C) 2022  Wilfred van Velzen")
+  print(" //  Checks nodelist segments for flag errors.")
+  print("This program comes with ABSOLUTELY NO WARRANTY")
+  print("This is free software, and you are welcome to redistribute it")
+  print()
+  if len(sys.argv) > 1:
+    if sys.argv[1] == '/?':
+      print('Syntax:')
+      print()
+      print('ERRFLAGS [control file]')
+      print()
+      print('    control file  Optional control file name. Can be used when processing')
+      print('                  segments in different zones.')
+      print('                  Default file name is ERRFLAGS.CTL')
+      print()
+      sys.exit(0)
+    ctlFileName = sys.argv[1]
+  oldDir = os.getcwd()
+
+
+def openConfigFileHelper(configFileNames, haltOnError):
+  error = True
+  configFileName = ""
+  configFile = None
+  for configFileName in configFileNames:
+    try:
+      configFile = open(configFileName)
+      error = False
+      break
+    except:
+      error = True
+
+  if error and haltOnError:
+    print('! Unable to open ', configFileNames[0], ' - exiting...', file=sys.stderr)
+    sys.exit(1)
+
+  return error, configFileName, configFile
+
+
+def openConfigFile(defaultConfigFileNames, configFileName, haltOnError):
+  if configFileName:
+    return openConfigFileHelper((configFileName,), haltOnError)
+
+  return openConfigFileHelper(defaultConfigFileNames, haltOnError)
+
+
+def ExecuteCommand(lbl, cmd, old_dir):
+  print('#', lbl + ':', cmd)
+  try:
+    subprocess.call(cmd, shell=True)
+    os.chdir(old_dir)
+  except Exception as e:
+    print("Error:", e, file=sys.stderr)
+
+
+# Parses the configuration file
+def ParseCTLFile():
+  global ctlFileName, DefaultZone, DefaultNet, MaxEntryLength, Touch, InboundPath, NotifyPath, NotifyCmd, NoErrCmd \
+       , NotifyPath, ExecuteCmd, ExecutePath, tabFileName, cmtFileName, UnCompressArc, UnCompressZip, SegmentFiles
+
+  error, ctlFileName, ctl_file = openConfigFile(DEFAULT_CTL_FILE_NAMES, ctlFileName, True)
+  for line in ctl_file:
+    line = line.strip()
+    if line and line[0] != ';':
+      key_word, line = first_word(line)
+      key_word = key_word.upper()
+      if key_word == 'ZONE':
+        DefaultZone = str2int(line)
+      elif key_word == 'NET':
+        DefaultNet = str2int(line)
+      elif key_word == 'MAXENTRYLENGTH':
+        MaxEntryLength = str2int(line)
+      elif key_word == 'NOTOUCH':
+        Touch = False
+      elif key_word == 'FILE':
+        fileName, line = first_word(line)
+        notifier, line = first_word(line)
+        rptFile , line = first_word(line)
+        if not rptFile:
+          rptFile = os.path.splitext(fileName)[0] + ".rpt"
+        SegmentFiles.append(TSegmentFile(fileName, rptFile, notifier))
+      elif key_word == 'INBOUND':
+        InboundPath = line
+      elif key_word == 'NOTIFY':
+        NotifyCmd = line
+      elif key_word == 'NOERR':
+        NoErrCmd = line
+      elif key_word == 'NOTIFYPATH':
+        NotifyPath = line
+      elif key_word == 'EXECUTE':
+        ExecuteCmd = line
+      elif key_word == 'EXECUTEPATH':
+        ExecutePath = line
+      elif key_word == 'TABFILE':
+        tabFileName = line
+      elif key_word == 'CMTFILE':
+        cmtFileName = line
+      elif key_word == 'UNCOMPRESS':
+        UnCompressArc = line
+      elif key_word == 'UNCOMPRESSZIP':
+        UnCompressZip = line
+  ctl_file.close()
+
+
+# Parses the approved flag file
+def ParseTabFile():
+  global tabFileName, BaudDefault, Baudrates, ApprFlags, CatFlags, UserFlags, ConvFlags, ReduntFlags, ReduntForPrefFlags, DelEntrys
+
+  error, tabFileName, tab_file = openConfigFile(DEFAULT_TAB_FILE_NAMES, tabFileName, True)
+  for line in tab_file:
+    line = line.strip()
+    if line and line[0] != ';':
+      key_word, line = first_word(line)
+      key_word = key_word.upper()
+      if key_word == 'BAUDDEFAULT':
+        BaudDefault, line = first_word(line)
+        BaudDefault = str2int(BaudDefault)
+      elif key_word == 'BAUDRATE':
+        while line:
+          baudrate, line = first_word(line)
+          Baudrates.append(str2int(baudrate))
+      elif key_word == 'FLAGS':
+        while line:
+          appr_flag, line = first_word(line)
+          ApprFlags.append(appr_flag.upper())
+      elif key_word == 'CFLAGS':
+        while line:
+          cat_flag, line = first_word(line)
+          CatFlags.append(cat_flag.upper())
+      elif key_word == 'USER':
+        while line:
+          user_flag, line = first_word(line)
+          UserFlags.append(user_flag.upper())
+      elif key_word == 'CONVERT':
+        while line:
+          first, line = first_word(line)
+          last , line = first_word(line)
+          ConvFlags.append(TConvFlag(first.upper(), last.upper()))
+      elif key_word == 'REDUNDANT':
+        first, line = first_word(line)
+        rflags = []
+        while line:
+          last, line = first_word(line)
+          lup = last.upper()
+          if lup in rflags:
+            print("WARNING: Flag", last, "specified more then once in", tabFileName, "file for 'REDUNDANT", first, "...'", file=sys.stderr)
+          else:
+            rflags.append(lup)
+        ReduntFlags.append(TConvFlag(first.upper(), rflags))
+      elif key_word == 'REDUNDANTFORPREFIX':
+        first, line = first_word(line)
+        rflags = []
+        while line:
+          last, line = first_word(line)
+          lup = last.upper()
+          if lup in rflags:
+            print("WARNING: Flag", last, "specified more then once in", tabFileName, "file for 'REDUNDANTFORPREFIX", first, "...'", file=sys.stderr)
+          else:
+            rflags.append(lup)
+        ReduntForPrefFlags.append(TConvFlag(first, rflags))
+      elif key_word == 'DELENTRY':
+        while line:
+          del_entry, line = first_word(line)
+          DelEntrys.append(del_entry.upper())
+  tab_file.close()
+
+
+# Check flags for equality, supporting a few macros in the process
+def is_equal(test, against):
+  global ThisCaseConv
+
+  passed = (len(test) == len(against)) or ((len(test) > len(against)) and ('*' in against))
+  L = 0
+  while (passed and (L < len(test))):
+    C = test[L]
+    if against[L] == '$':
+      passed = C.isalpha()
+    elif against[L] == '@':
+      passed = C.isdecimal()
+    elif against[L] == '?':
+      passed = True
+    elif against[L] == '*':
+      passed = True
+      L = len(test)
+    else:
+      test = test[:L] + test[L].upper() + test[L + 1:]
+      if test[L] != C:
+        ThisCaseConv += 1
+      passed = test[L] == against[L].upper()
+    L += 1
+  return passed, test
+
+
+# Checks the entry's phonenumber validity
+def PhoneOK(phonenumber):
+  ok = True
+  if phonenumber[0] == '-':
+    if phonenumber.upper() == '-UNPUBLISHED-':
+      phonenumber = unpub
+    else:
+      ok = False
+  elif phonenumber[:3] == '000':  # no smuggling of IP addresses
+    ok = False
+  else:                           # it must be a phone-number
+    ok = all(ch in '-0123456789' for ch in phonenumber)
+  return ok, phonenumber
+
+
+def split_flags_str(str):
+  return [flag for flag in str.split(comma) if flag]
+
+
+def remove_duplicate_flags(flags, report_node):
+  global ThisDupErr
+  for n1, nflag1 in enumerate(flags[:-1]):
+    if nflag1:
+      for n2, nflag2 in enumerate(flags[n1 + 1:], start=n1 + 1):
+        if nflag2 and nflag1 == nflag2:
+          print_and_report("WARNING: duplicate flag " + nflag2 + " for " + report_node)
+          flags[n2] = ""
+          ThisDupErr += 1
+
+
+def convert_flags(flags, report_node):
+  global ThisConverted
+  for fi, flag in enumerate(flags):
+    for conv_flag in ConvFlags:
+      if conv_flag.First == flag.upper():
+        print_and_report("WARNING: converted flag " + flag + " to " + conv_flag.Last + " for "+ report_node)
+        flags[fi] = conv_flag.Last
+        ThisConverted += 1
+        break
+
+
+# Checks the entry's nodelist flags for errors and fixes them.
+def FixFlags(flags, report_node, prefix):
+  global ThisFlagErr, ThisReduErr, ThisUserErr, ThisDupErr
+
+  # Divide the flags into normal and user flags
+  user_start = flags.find(',U')
+  if user_start >= 0:
+    NrmFlags = flags[:user_start]
+    UsrFlags = flags[user_start + 2:].replace(",U", ",")
+  else:
+    NrmFlags = flags
+    UsrFlags = ""
+
+  NFlags = split_flags_str(NrmFlags)
+  convert_flags(NFlags, report_node)
+
+  # Check for invalid flags
+  for ni, nflag in enumerate(NFlags):
+    Passed = False
+    for appr_flag in ApprFlags:
+      Passed, nflag = is_equal(nflag, appr_flag)
+      NFlags[ni] = nflag
+      if Passed:
+        break
+    if not Passed:
+      temp = nflag
+      for cat_flag in CatFlags:
+        temp = temp.replace(cat_flag, "", 1)
+      Passed = (temp == "")
+      if not Passed:
+        print_and_report('ERROR  : invalid flag ' + nflag + ' for ' + report_node)
+        NFlags[ni] = ""
+        ThisFlagErr += 1
+
+  # Check for redundant combination of prefix and flag
+  for redunt_for_pref_flag in ReduntForPrefFlags:
+    if prefix == redunt_for_pref_flag.First:
+      for nflag in NFlags:
+        if nflag and nflag in redunt_for_pref_flag.Last:
+          print_and_report('WARNING: incompatible flag ' + nflag + ' for ' + prefix + ' node ' + report_node)
+          ThisReduErr += 1
+
+  # Remove redundant flags
+  for ni, nflag in enumerate(NFlags):
+    if nflag:
+      for redunt_flag in ReduntFlags:
+        if redunt_flag.First in NFlags and nflag in redunt_flag.Last:
+          print_and_report('WARNING: redundant flag ' + nflag + ' due to ' + redunt_flag.First + ' for ' + report_node)
+          NFlags[ni] = ""
+          ThisReduErr += 1
+          break  # 1x reporting per flag is enough
+
+  remove_duplicate_flags(NFlags, report_node)
+
+  # Check user flags
+  UFlags = split_flags_str(UsrFlags)
+  convert_flags(UFlags, report_node)
+
+  for ui, uflag in enumerate(UFlags):
+    Passed = False
+    for user_flag in UserFlags:
+      Passed, uflag = is_equal(uflag, user_flag)
+      UFlags[ui] = uflag
+      if Passed:
+        break
+    if not Passed:
+      print_and_report('ERROR  : invalid user flag ' + uflag + ' for ' + report_node)
+      UFlags[ui] = ""
+      ThisUserErr += 1
+
+  remove_duplicate_flags(UFlags, report_node)
+
+  # Remove deleted flags
+  NFlags = [flag for flag in NFlags if flag]
+  UFlags = [flag for flag in UFlags if flag]
+
+  flags = comma + ",".join(NFlags) if NFlags else ""
+  if UFlags:
+    flags += ",U," + ",".join(UFlags)
+  return flags
+
+
+# Initial parser of segment line since MakeNl makes checks on the normal fields,
+# we do not check them but checks should go here
+def ParseNodeLine(line: str):
+  global ThisZone, ThisNet \
+       , ThisBaudErr, ThisPhoneErr, ThisPrefixErr, ThisPvtErr, ThisSpaces, ThisTailCommas, ThisDelEntry
+
+  do_del_spaces = ' ' in line
+  if do_del_spaces:
+    line = line.replace(' ', '')
+
+  Prefix, line = extract(line)
+  Prefix = Prefix.capitalize()
+  Node, line = extract(line)
+  if Prefix == 'Zone':
+    ThisZone = str2int(Node)
+    CurrentNode = Node + ':' + Node + '/0'
+  elif Prefix == 'Region' or Prefix == 'Host':
+    ThisNet = str2int(Node)
+    CurrentNode = str(ThisZone) + ':' + Node + '/0'
+  else:
+    CurrentNode = str(ThisZone) + ':' + str(ThisNet) + '/' + Node
+    if Prefix and not (Prefix == 'Hub' or Prefix == 'Pvt' or Prefix == 'Hold' or Prefix == 'Down'):
+      print_and_report('ERROR  : unknown prefix "' + Prefix + '" for ' + CurrentNode)
+      Prefix = ''
+      ThisPrefixErr += 1
+
+  if do_del_spaces:
+    print_and_report('WARNING: space(s) removed for ' + CurrentNode)
+    ThisSpaces += 1
+
+  if line and line[-1] == comma:
+    line = line.rstrip(comma)
+    print_and_report('WARNING: tail comma(s) removed for ' + CurrentNode)
+    ThisTailCommas += 1
+
+  SystemName, line = extract(line)
+  Location, line = extract(line)
+  AdminName, line = extract(line)
+
+  if AdminName.upper() in DelEntrys:
+    print_and_report('WARNING: entry for ' + CurrentNode + ', SysOp ' + AdminName + ', removed.')
+    ThisDelEntry += 1
+    return ""
+
+  PhoneNr, line = extract(line)
+  Ok, PhoneNr = PhoneOK(PhoneNr)
+  if not Ok:
+    print_and_report('WARNING: invalid phonenumber "' + PhoneNr + '" for ' + CurrentNode)
+    PhoneNr = unpub
+    if Prefix == '':
+      Prefix = 'Pvt'
+    ThisPhoneErr += 1
+
+  if Prefix == 'Pvt' and PhoneNr != unpub:
+    print_and_report("WARNING: Pvt prefix should have " + unpub + " phonenumber for " + CurrentNode)
+    PhoneNr = unpub
+    ThisPvtErr += 1
+
+  BaudrateStr, line = extract(line)
+  Baudrate = str2int(BaudrateStr)
+  if Baudrate not in Baudrates:
+    print_and_report('WARNING: invalid baudrate ' + BaudrateStr + ' for ' + CurrentNode)
+    Baudrate = BaudDefault
+    ThisBaudErr += 1
+
+  AllFlags = FixFlags(comma + line, CurrentNode, Prefix)
+  LenLine = len(Prefix) + len(Node) + len(SystemName) + len(Location) + len(AdminName) + len(PhoneNr) \
+          + len(str(Baudrate)) + len(AllFlags) + 6
+  LenToStrip = LenLine - MaxEntryLength
+  if LenToStrip > 0:
+    print_and_report('WARNING: entry for ' + CurrentNode + ' of ' + str(LenLine) + ' chars cut to ' + str(MaxEntryLength) + ' for MAKENL')
+    if len(SystemName) > LenToStrip:
+      SystemName = SystemName[:-LenToStrip]
+    else:
+      LenToStrip = LenToStrip - len(SystemName) + 3
+      SystemName = SystemName[:1]
+      if LenToStrip > 0:
+        if len(Location) > LenToStrip:
+          Location = Location[:-LenToStrip]
+        else:
+          LenToStrip = LenToStrip - len(Location) + 1
+          Location = Location[:1]
+          if LenToStrip > 0:
+            print_and_report('= BEWARE: cut ' + str(LenToStrip) + ' chars from Flags as well!', prechar='=')
+            AllFlags = FixFlags(AllFlags[:-LenToStrip], CurrentNode, Prefix)
+
+  return Prefix + comma + Node + comma + SystemName + comma + Location + comma \
+       + AdminName + comma + PhoneNr + comma + str(Baudrate) + AllFlags
+
+
+# Set locale to English?
+def NextFriday():
+  t = time.time()
+  lt = time.localtime(t + ((4 - time.localtime(t).tm_wday) % 7) * 86400)
+  return time.strftime("%A, %B " + str(lt.tm_mday) + ", %Y", lt) \
+       , time.strftime("%j", lt)
+
+
+# OS independent case-insensitive pattern matching.
+def iglob(path: str, pattern: str):
+  def either(c):
+    return '[' + c.lower() + c.upper() + ']' if c.isalpha() else c
+  return glob.glob(os.path.join(path, ''.join(either(c) for c in pattern)))
+
+
+# Return first file that matches pattern case-insensitive
+def find_ifile(path: str, pattern: str):
+  for fn in iglob(path, pattern):
+    if os.path.isfile(fn):
+      return fn
+  return ""
+
+
+def uncompress(command, inbound_path, filename):
+  if not command:
+    return True
+
+  old_dir = os.getcwd()
+  try:
+    os.chdir(inbound_path)
+    fn = find_ifile("", filename)
+    if fn:
+      cmd = ireplace('%FILE%', fn, command)
+      print("# Uncompressing: '" + fn + "' in dir: '" + inbound_path + "' with command: '" + cmd + "'")
+      subprocess.call(cmd, shell=True)
+      os.remove(fn)
+    else:
+      return False
+  except Exception as e:
+    print('! Error in uncompress:', e, file=sys.stderr)
+    return False
+  finally:
+    os.chdir(old_dir)
+
+  return True
+
+
+def uncompress_select(inbound_path, filename, ext):
+  if len(ext) > 1:
+    uncompress_type = ext[1].upper()
+    if   uncompress_type == 'A':
+      return uncompress(UnCompressArc, inbound_path, filename)
+    elif uncompress_type == 'Z':
+      return uncompress(UnCompressZip, inbound_path, filename)
+  return True
+
+
+# Find file names with wild cards, and extract any ARC'd data files
+def ExtractFile(inbound_path: str, filename: str):
+  if '*' not in filename:
+    return find_ifile(inbound_path, filename)
+
+  basename, ext = os.path.splitext(filename)
+  if uncompress_select(inbound_path, filename, ext):
+    return find_ifile(inbound_path, basename + '.*')
+
+  return ""
+
+
+# Checks complete segment files, creating a fixed segment file together with a report file for notification
+def CheckSegment(inbound_path, segment_filename, report_filename, notify_node):
+  global ThisZone, ThisNet, cmtFileName, RptFile, oldDir, AnyProcessed, NotifyCmd, NoErrCmd\
+       , ThisPrefixErr, ThisPvtErr, ThisPhoneErr, ThisBaudErr, ThisFlagErr, ThisUserErr, ThisReduErr, ThisDupErr\
+       , ThisCaseConv, ThisConverted, ThisSpaces, ThisTailCommas, ThisDelEntry\
+       , TotPrefixErr, TotPvtErr, TotPhoneErr, TotBaudErr, TotFlagErr, TotUserErr, TotReduErr, TotDupErr\
+       , TotCaseConv, TotConverted, TotSpaces, TotTailCommas, TotDelEntry
+
+  segment_filename = ExtractFile(inbound_path, segment_filename)
+  if not segment_filename:
+    return
+
+  ThisZone       = DefaultZone
+  ThisNet        = DefaultNet
+  ThisPrefixErr  = 0
+  ThisPvtErr     = 0
+  ThisPhoneErr   = 0
+  ThisBaudErr    = 0
+  ThisFlagErr    = 0
+  ThisUserErr    = 0
+  ThisReduErr    = 0
+  ThisDupErr     = 0
+  ThisCaseConv   = 0
+  ThisConverted  = 0
+  ThisSpaces     = 0
+  ThisTailCommas = 0
+  ThisDelEntry   = 0
+  AmDate, DayNum = NextFriday()
+  Default_NLheader = ';A Fidonet Nodelist for ' + AmDate + daynumstr + DayNum + ' : 00000'
+  OutFile   = None
+  TempFName = GetTempFileName(segment_filename)
+  if Touch:
+    infname = TempFName
+    try:
+      os.replace(segment_filename, TempFName)
+    except OSError as e:
+      if e.errno != 2:  # file not found is normal
+        print('! Unable to rename', segment_filename, 'to', TempFName, '- error:', e, file=sys.stderr)
+      return
+    try:
+      OutFile = open(segment_filename, "w", encoding=codec, newline=crlf)
+    except OSError as e:
+      print('! Unable to create', segment_filename, '- error:', e, file=sys.stderr)
+      return
+  else:
+    infname = segment_filename
+
+  try:
+    InFile = open(infname, encoding=codec)
+  except OSError as e:
+    if e.errno != 2:  # file not found is normal
+      print('! Unable to open', infname, '- error:', e, file=sys.stderr)
+    return
+
+  try:
+    RptFile = open(report_filename, "w", encoding=codec)
+  except OSError as e:
+    print('! Unable to create', report_filename, '- error:', e, file=sys.stderr)
+    return
+
+  error, cmtFileName, cmt_file = openConfigFile(DEFAULT_CMT_FILE_NAMES, cmtFileName, False)
+  if not error:
+    RptFile.writelines(cmt_file.readlines())
+    cmt_file.close()
+    print(file=RptFile)
+
+  print_and_report('Processing file ' + segment_filename)
+  handle_first_crc_line = True
+  crc_line = ''
+  crc = 0
+
+  for line in InFile:
+    line = line.rstrip()    # remove CR
+    if line and line[0] == chr(26):  # Ignore 'soft' EOF character
+      line = line[1:]
+      if not line:
+        continue
+    if handle_first_crc_line:
+      handle_first_crc_line = False
+      if is_crcline(line):
+        crc_line = line
+      else:
+        crc_line = Default_NLheader
+    if line and line[0] != ';':
+      line = ParseNodeLine(line)
+    if Touch and line:
+      print(line, file=OutFile)
+      if crc_line != line:
+        crc = crc16str(crc, line + crlf)
+
+  InFile.close()
+  if Touch:
+    OutFile.close()
+    os.remove(infname)
+    crc_line = crc_line.rstrip('0123456789') + ("%05d" % crc)
+    print(crc_line)
+    os.replace(segment_filename, TempFName)
+    try:
+      OutFile = open(segment_filename, "w", encoding=codec, newline=crlf)
+    except OSError as e:
+      print('! Unable to create', segment_filename, '- error', e, file=sys.stderr)
+      return
+
+    InFile = open(TempFName, encoding=codec)
+    line = InFile.readline().rstrip()
+    print(crc_line, file=OutFile)
+    if not is_crcline(line):
+      print(line, file=OutFile)
+    for line in InFile:
+      print(line.rstrip(), file=OutFile)
+    InFile.close()
+    OutFile.close()
+    try:
+      os.remove(TempFName)
+    except OSError as e:
+      print('! Unable to delete temporary file - error:', e, file=sys.stderr)
+      return
+
+  print()
+  print(file=RptFile)
+  print_and_report('SUMMARY REPORT FOR THIS NODELIST SEGMENT:', prechar='*')
+  print_and_report('Prefix errors            : %d' % ThisPrefixErr, prechar='>')
+  print_and_report('Pvt/phone errors         : %d' % ThisPvtErr, prechar='>')
+  print_and_report('Phonenumber errors       : %d' % ThisPhoneErr, prechar='>')
+  print_and_report('Baudrate errors          : %d' % ThisBaudErr, prechar='>')
+  print_and_report('Flag errors              : %d' % ThisFlagErr, prechar='>')
+  print_and_report('User flag errors         : %d' % ThisUserErr, prechar='>')
+  print_and_report('Redundant flags          : %d' % ThisReduErr, prechar='>')
+  print_and_report('Duplicate flags          : %d' % ThisDupErr, prechar='>')
+  print_and_report('Case conversions         : %d' % ThisCaseConv, prechar='>')
+  print_and_report('Converted flags          : %d' % ThisConverted, prechar='>')
+  print_and_report('Entries with spaces      : %d' % ThisSpaces, prechar='>')
+  print_and_report('Entries with tail commas : %d' % ThisTailCommas, prechar='>')
+  print_and_report('Deleted entries          : %d' % ThisDelEntry, prechar='>')
+  print()
+  print("\n // ErrFlags v" + ErrFlagsVersion, file=RptFile)
+  RptFile.close()
+
+  TotPrefixErr += ThisPrefixErr
+  TotPvtErr    += ThisPvtErr
+  TotPhoneErr  += ThisPhoneErr
+  TotBaudErr   += ThisBaudErr
+  TotFlagErr   += ThisFlagErr
+  TotUserErr   += ThisUserErr
+  TotReduErr   += ThisReduErr
+  TotDupErr    += ThisDupErr
+  TotCaseConv  += ThisCaseConv
+  TotConverted += ThisConverted
+  TotSpaces    += ThisSpaces
+  TotTailCommas+= ThisTailCommas
+  TotDelEntry  += ThisDelEntry
+  AnyProcessed = True
+
+  if ThisPrefixErr + ThisPvtErr + ThisPhoneErr + ThisBaudErr + ThisFlagErr + ThisUserErr + ThisReduErr + ThisDupErr > 0:
+    if not NotifyCmd:
+      return
+    else:
+      cmd = NotifyCmd
+  else:
+    if not NoErrCmd:
+      return
+    else:
+      cmd = NoErrCmd
+  try:
+    os.chdir(NotifyPath)
+  except OSError as e:
+    print('! Unable to CD to path', NotifyPath, '- error:', e, file=sys.stderr)
+    return
+  cmd = ireplace("%NODE%", notify_node, cmd)
+  cmd = ireplace("%FILE%", report_filename, cmd)
+  ExecuteCommand('Notify', cmd, oldDir)
+
+
+def init():
+  SignOn()
+  ParseCTLFile()
+  ParseTabFile()
+
+
+def handle_segment_files():
+  global SegmentFiles
+
+  for segment_file in SegmentFiles:
+    CheckSegment(InboundPath, segment_file.FileName, segment_file.RptFile, segment_file.Notifier)
+
+
+def executecmd_when_any_processed():
+  global AnyProcessed, ExecutePath, ExecuteCmd, oldDir
+
+  if AnyProcessed and ExecuteCmd:
+    if ExecutePath:
+      try:
+        os.chdir(ExecutePath)
+      except OSError as e:
+        print('! Unable to CD to path ', ExecutePath, ' - error:', e, file=sys.stderr)
+        return
+    ExecuteCommand('Execute', ExecuteCmd, oldDir)
+
+
+def final_report():
+  global TotPrefixErr, TotPvtErr, TotPhoneErr, TotBaudErr, TotFlagErr, TotUserErr \
+       , TotReduErr, TotDupErr, TotCaseConv, TotConverted, TotSpaces, TotTailCommas, TotDelEntry
+  print()
+  print('* FINAL REPORT FOR ALL PROCESSED NODELIST SEGMENTS:')
+  print('> Total prefix errors            : %d' % TotPrefixErr)
+  print('> Total Pvt/phone errors         : %d' % TotPvtErr)
+  print('> Total phonenumber errors       : %d' % TotPhoneErr)
+  print('> Total baudrate errors          : %d' % TotBaudErr)
+  print('> Total flag errors              : %d' % TotFlagErr)
+  print('> Total user flag errors         : %d' % TotUserErr)
+  print('> Total redundant flags          : %d' % TotReduErr)
+  print('> Total duplicate flags          : %d' % TotDupErr)
+  print('> Total case conversions         : %d' % TotCaseConv)
+  print('> Total converted flags          : %d' % TotConverted)
+  print('> Total entries with spaces      : %d' % TotSpaces)
+  print('> Total entries with tail commas : %d' % TotTailCommas)
+  print('> Total deleted entries          : %d' % TotDelEntry)
+
+
+def main():
+  init()
+  handle_segment_files()
+  executecmd_when_any_processed()
+  final_report()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Hi Niels,

Hierbij een python versie van errflags. Deze werkt exact hetzelfde als de pascal versie, en is bedoeld als een drop-in vervanger voor de gecompileerde pascal versie, voor mensen die het gemakkelijker vinden om een python script hiervoor te gebruiken. Er zijn alleen wat cosmetische verschillen in de output.

Om aan je project toe te voegen als je wilt.